### PR TITLE
Update 04_5_Sending_Coins_with_Automated_Raw_Transactions.md

### DIFF
--- a/04_5_Sending_Coins_with_Automated_Raw_Transactions.md
+++ b/04_5_Sending_Coins_with_Automated_Raw_Transactions.md
@@ -99,7 +99,7 @@ $ bitcoin-cli -named decoderawtransaction hexstring=$rawtxhex3
 }
 ```
 We saw the fee in the more extensive output, before we saved the hex to a variable with JQ, but you can verify it with the `btctxfee` JQ alias:
-```
+```#Where is this command btxfee eralier specified? Can't find it?!
 $ btctxfee $rawtxhex3
 .00023
 ```


### PR DESCRIPTION
Where is the btctxfee specified?