### PR TITLE
Update 04_4_Sending_Coins_with_a_Raw_Transaction.md

### DIFF
--- a/04_4_Sending_Coins_with_a_Raw_Transaction.md
+++ b/04_4_Sending_Coins_with_a_Raw_Transaction.md
@@ -102,7 +102,7 @@ Here's the example. Note the multiple inputs after the `inputs` arg and the mult
 ```
 $ rawtxhex2=$(bitcoin-cli -named createrawtransaction inputs='''[ { "txid": "'$utxo_txid_1'", "vout": '$utxo_vout_1' }, { "txid": "'$utxo_txid_2'", "vout": '$utxo_vout_2' } ]''' outputs='''{ "'$recipient'": 0.009, "'$changeaddress'": 0.0009 }''')
 ```
-We were _very_ careful figuring out our money math. These two UTXOs contain 5.85 BTC. After sending 0.009 BTC, we'll have .00099999 BTC left. We chose .00009999 BTC the transaction fee. To accommodate that fee, we set our change to .0009 BTC. If we'd messed up our math and instead set our change to .00009 BTC, that additional BTC would be lost to the miners! If we'd forgot to make change at all, then the whole excess would have disappeared. So, again, _be careful_. 
+We were _very_ careful figuring out our money math. These two UTXOs contain 0.00999999 BTC. After sending 0.009 BTC, we'll have .00099999 BTC left. We chose .00009999 BTC the transaction fee. To accommodate that fee, we set our change to .0009 BTC. If we'd messed up our math and instead set our change to .00009 BTC, that additional BTC would be lost to the miners! If we'd forgot to make change at all, then the whole excess would have disappeared. So, again, _be careful_. 
 
 Fortunately, we can triple-check with the `btctxfee` alias from the JQ Interlude:
 ```


### PR DESCRIPTION
the output of listunspent must have been updated but this reference in the text was never updated in tandem