### PR TITLE
Update A2_0_Compiling_Bitcoin_from_Source.md

### DIFF
--- a/A2_0_Compiling_Bitcoin_from_Source.md
+++ b/A2_0_Compiling_Bitcoin_from_Source.md
@@ -84,8 +84,10 @@ Once you've selected a tag branch, execute the following from inside the `bitcoi
 ```
 $ ./autogen.sh
 $ export BDB_PREFIX='<PATH-TO>/db4'
+$ ./configure help # to see commands 
 $ ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
-$ make  # build bitcoin core
+$ make -j"$(($(nproc)+1))"  # makes bitcoin core with all threads on linux 
+$ make -j"$(($(sysctl -n hw.physicalcpu)+1))" # on macOS
 ```
 
 ### Step 6: Test the Build


### PR DESCRIPTION
Adding the make command that uses all available threads on linux and macOS - building core can take a very long time without it.