### PR TITLE
fix for jq auto formatting decimals

### DIFF
--- a/src/04_2_i_txfee-calc.sh
+++ b/src/04_2_i_txfee-calc.sh
@@ -10,4 +10,5 @@ usedtxid=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .txid'))
 usedvout=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .vout'))
 btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'${txid}'")) | select(.vout | contains('$vout')) | .amount'; done | awk '{s+=$1} END {print s}')
 btcout=$(bitcoin-cli decoderawtransaction $1 | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print s}')
+btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%f\n", btcout) }' </dev/null)
 echo "$btcin-$btcout"| /usr/bin/bc

--- a/src/04_2_i_txfee-calc.sh
+++ b/src/04_2_i_txfee-calc.sh
@@ -11,4 +11,4 @@ usedvout=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .vout'))
 btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'${txid}'")) | select(.vout | contains('$vout')) | .amount'; done | awk '{s+=$1} END {print s}')
 btcout=$(bitcoin-cli decoderawtransaction $1 | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print s}')
 btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%f\n", btcout) }' </dev/null)
-echo "$btcin-$btcout"| /usr/bin/bc
+echo "$btcin-$btcout_f"| /usr/bin/bc


### PR DESCRIPTION
jq auto formats decimals to scientific notation so the calculation on the last line of the script fails on a syntax error:

For example:
```
$ echo "0.0001 - 9.5e-05" | /usr/bin/bc
(standard_in) 1: syntax error
```
vs this:
```
$ echo "0.0001 - 0.000095" | /usr/bin/bc
.000005
```