### PR TITLE
03_1_Verifying_Your_Bitcoin_Setup.md: Added .bashrc and .profile as o…

### DIFF
--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -6,7 +6,7 @@ Before you start playing with Bitcoin, you should ensure that everything is setu
 
 We suggest creating some aliases to make it easier to use Bitcoin.
 
-You can do so by putting them in your `.bash_profile`.
+You can do so by putting them in your `.bash_profile`, `.bashrc` or `.profile`.
 ```
 cat >> ~/.bash_profile <<EOF
 alias btcdir="cd ~/.bitcoin/" #linux default bitcoind path


### PR DESCRIPTION
…ptions along with .bash_profile

There is no `.bash_profile` on Debian. Irrespectively of the Linux distro `.bashrc` is likely to be the file where most Linux users place there aliases.