### PR TITLE
Add `-getinfo`

### DIFF
--- a/03_2_Knowing_Your_Bitcoin_Setup.md
+++ b/03_2_Knowing_Your_Bitcoin_Setup.md
@@ -196,7 +196,7 @@ Result:
 }
 
 Examples:
-> bitcoin-cli getmininginfo 
+> bitcoin-cli getmininginfo
 > curl --user myusername --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getmininginfo", "params": []}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
 ```
 > :book: ***What is RPC?*** `bitcoin-cli` is just a handy interface that lets you send commands to the `bitcoind`. More specifically, it's an interface that lets you send RPC (or Remote Procedure Protocol) commands to the `bitcoind`. Often, the `bitcoin-cli` command and the RPC command have identical names and interfaces, but some `bitcoin-cli` commands instead provide shortcuts for more complex RPC requests. Generally, the `bitcoin-cli` interface is much cleaner and simpler than trying to send RPC commands by hand, using `curl` or some other method. However, it also has limitations as to what you can ultimately do.
@@ -204,6 +204,37 @@ Examples:
 ## Optional: Know Your Bitcoin Info
 
 A variety of bitcoin-cli commands can give you additional information on your bitcoin data. The most general ones are:
+
+`bitcoin-cli -getinfo` returns information from different RPCs (user-friendly)
+
+```diff
+$ bitcoin-cli -getinfo
+
+! Chain: test
+Blocks: 1977694
+Headers: 1977694
+Verification progress: 0.9999993275374796
+Difficulty: 1
+
++ Network: in 0, out 8, total 8
+Version: 219900
+Time offset (s): 0
+Proxy: N/A
+Min tx relay fee rate (BTC/kvB): 0.00001000
+
+@@ Wallet: ""@@
+Keypool size: 1000
+Unlocked until: 0
+Transaction fee rate (-paytxfee) (BTC/kvB): 0.00000000
+
+# Balance: 0.02853102
+
+- Warnings: unknown new rules activated (versionbit 28)
+
+```
+
+Other commands to get information about blockchain, mining, network, wallet etc.
+
 ```
 $ bitcoin-cli getblockchaininfo
 $ bitcoin-cli getmininginfo


### PR DESCRIPTION
Add `bitcoin-cli -getinfo` with an example(testnet) in [`Optional: Know Your Bitcoin Info`](https://github.com/BlockchainCommons/Learning-Bitcoin-from-the-Command-Line/blob/master/03_2_Knowing_Your_Bitcoin_Setup.md#optional-know-your-bitcoin-info) which returns information from different RPCs categorized in a user friendly way and also uses colors for output in terminal

Results for `-getinfo` will be similar to the example once PR: https://github.com/bitcoin/bitcoin/pull/21832 is merged