### PR TITLE
Fix indexing typos

### DIFF
--- a/04_2__Interlude_Using_JQ.md
+++ b/04_2__Interlude_Using_JQ.md
@@ -51,7 +51,7 @@ $ bitcoin-cli sendrawtransaction $signedtx
 
 Grabbing data out of a JSON object is easy, but what if that JSON object is in a JSON array? The `listunspent` command offers a great example, because it'll usually contain a number of different transactions. What if you want to capture specific information from _one_ of them?
 
-When working with a JSON array, the first thing you need to do is tell JQ which index to access. For example, you might have looked through your transactions in `listunspent` and decided that you wanted to work with the second of them. You use `'.[1]'` to access that first element. The `[]` says that we're referencing a JSON array and the `0` says we want the 0th index.
+When working with a JSON array, the first thing you need to do is tell JQ which index to access. For example, you might have looked through your transactions in `listunspent` and decided that you wanted to work with the second of them. You use `'.[1]'` to access that second element. The `[]` says that we're referencing a JSON array and the `1` says we want the 1st index.
 ```
 $ bitcoin-cli listunspent | jq -r '.[1]'
 {
@@ -68,7 +68,7 @@ $ bitcoin-cli listunspent | jq -r '.[1]'
   "safe": true
 }
 ```
-You can then capture an individual value from that selected array by (1) using a pipe _within_ the JQ arguments; and then (2) requesting the specific value afterward, as in the previous example. The following would capture the `txid` from the 0th JSON object in the JSON array produced by `listunspent`:
+You can then capture an individual value from that selected array by (1) using a pipe _within_ the JQ arguments; and then (2) requesting the specific value afterward, as in the previous example. The following would capture the `txid` from the 1st JSON object in the JSON array produced by `listunspent`:
 ```
 $ bitcoin-cli listunspent | jq -r '.[1] | .txid'
 91261eafae15ea53dedbea7c1db748c52bbc04a85859ffd0d839bda1421fda4c


### PR DESCRIPTION
There were some inconsistencies about the indexing of the examples. In
some places the txid starting with "91261eaf..." was indexed with a 1,
but it was reported as the first element of the array returned by the
command ```bitcoin-cli listunspent``` (an array with index starting from 0)
and later, in the same chapter, the same txid was reported as the
element with index 0 of the array returned by the same command.

Searching the txid  in text I deduced that the correct indexing for that
txid was 1. So I made changes accordingly.

Maybe the change in line 71 could be _...from the 2nd JSON object..._,
instead of _...from the 1st JSON object..._. So, I would like to hear other
opinions about this.