### PR TITLE
Add missing flag to bitcoin-cli command

### DIFF
--- a/04_6_Creating_a_Segwit_Transaction.md
+++ b/04_6_Creating_a_Segwit_Transaction.md
@@ -120,7 +120,7 @@ $ bitcoin-cli sendtoaddress tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx 0.005
 ```
 If you look at your transaction, you can see the use of the Bech32 address:
 ```
-$ bitcoin-cli gettransaction txid="854a833b667049ac811b4cf1cad40fa7f8dce8b0f4c1018a58b84559b6e05f42" verbose=true
+$ bitcoin-cli -named gettransaction txid="854a833b667049ac811b4cf1cad40fa7f8dce8b0f4c1018a58b84559b6e05f42" verbose=true
 {
   "amount": -0.00500000,
   "fee": -0.00036600,


### PR DESCRIPTION
As stated in one of the first chapters and used in other commands on the same chapter, `bitcoin-cli` commands were agreed to be used with the named argument. I don't know if the `bitcoin-cli` command was aliased before, but, without the alias, the example don't work. So it has to be called with the proper `-named` flag.