### PR TITLE
Fix broken link

### DIFF
--- a/06_1_Sending_a_Transaction_to_a_Multisig.md
+++ b/06_1_Sending_a_Transaction_to_a_Multisig.md
@@ -97,7 +97,7 @@ The _address_ is what you'll give out to people who want to send funds. You'll n
 
 > :link: **TESTNET vs MAINNET:** On testnet, the prefix for P2SH addresses is `2`, while on mainnet, it's `3`.
 
-The _redeemScript_ is what you need to redeem the funds (along with the private keys for "m" of the "n" addresses). This script is another special feature of P2SH addresses and will be fully explained in [§8.1: Building a Bitcoin Script with P2SH](08_1_Building_a_Bitcoin_Script_with_P2SH.md). For now, just be aware that it's a bit of data that's required to get your money.
+The _redeemScript_ is what you need to redeem the funds (along with the private keys for "m" of the "n" addresses). This script is another special feature of P2SH addresses and will be fully explained in [§10.3: Running a Bitcoin Script with P2SH](10_3_Running_a_Bitcoin_Script_with_P2SH.md). For now, just be aware that it's a bit of data that's required to get your money.
 
 The _descriptor_ is the standardized description for an address that we met in [§3.5: Understanding the Descriptor](03_5_Understanding_the_Descriptor.md). It provides one way that you could import this address back to the other machine, using the `importmulti` RPC.
 


### PR DESCRIPTION
The linked chapter (8.1) was neither about `redeemScript` nor was the link working (it lead to a 404). I checked and saw that chapter 10 is the one actually mentioning P2SH, and I assumed the best file was 10_3 because it is the one which more closely resembles "Building a Bitcoin Script with P2SH" (which is the linked yet broken file name) and also it mentions and deals with `redeemScript`.