### PR TITLE
Fix typo in chapter 3.4

### DIFF
--- a/03_4_Receiving_a_Transaction.md
+++ b/03_4_Receiving_a_Transaction.md
@@ -14,7 +14,7 @@ To use a faucet, you'll usually need to go to a URL and copy and paste in your a
 
 ## Verify Your Money
 
-After you've requested your money, you should be able to verify it with the 'bitcoin-cli getbalance' command:
+After you've requested your money, you should be able to verify it with the `bitcoin-cli getbalance` command:
 ```
 $ bitcoin-cli getbalance
 0.00000000


### PR DESCRIPTION
All the other commands where formatted with backticks instead of
straight quotation marks. Because they are very similar, I assume
that the intention was to write backticks.
