### PR TITLE
Fix some typos and links on Chapter 10

### DIFF
--- a/10_2_Building_the_Structure_of_P2SH.md
+++ b/10_2_Building_the_Structure_of_P2SH.md
@@ -171,7 +171,7 @@ Depending on your API, you might be able to enter this as an `asm`-style `script
 
 Note that the `hex scriptPubKey` for P2SH Script transaction will _always_ start with an `a914`, which is the `OP_HASH160` followed by an `OP_PUSHDATA` of 20 bytes (hex: `0x14`); and it will _always_ end with a `87`, which is an `OP_EQUAL`. So all you have to do is put your hashed redeem script in between those numbers.
 
-## Summary: Understanding the Foundation of P2SH
+## Summary: Building the Structure of P2SH
 
 Actually creating the P2SH locking script dives further into the guts of Bitcoin than you've ever gone before. Though it's helpful to know how all of this works at a very low level, it's most likely that you'll have an API taking care of all of the heavy-lifting for you. Your task will simply be to create the Bitcoin Script to do the locking ... which is the main topic of chapters 9 and 11-12.
 

--- a/10_4_Scripting_a_Multisig.md
+++ b/10_4_Scripting_a_Multisig.md
@@ -22,7 +22,7 @@ The requirement for that `0` as the first operand for `OP_CHECKMULTISIG` is a co
 
 ## Create a Raw Multisig 
 
-As discussed in [§10.1: Building a Bitcoin Script with P2SH](10_1_Building_a_Bitcoin_Script_with_P2SH.md), multisigs are one of the standard Bitcoin transaction types. A transaction can be created with a locking script that uses the raw `OP_CHECKMULTISIG` command, and it will be accepted into a block. This is the classic methodology for using multisigs in Bitcoin.
+As discussed in [§10.2: Building the Structure of P2SH](10_2_Building_the_Structure_of_P2SH.md), multisigs are one of the standard Bitcoin transaction types. A transaction can be created with a locking script that uses the raw `OP_CHECKMULTISIG` command, and it will be accepted into a block. This is the classic methodology for using multisigs in Bitcoin.
 
 As an example, we will revisit the multisig created in [§8.1](08_1_Sending_a_Transaction_to_a_Multisig.md) one final time and build a new locking script for it using this methodology. As you may recall, that was a 2-of-2 multisig built from `$address1` and `$address2`. 
 

--- a/10_4_Scripting_a_Multisig.md
+++ b/10_4_Scripting_a_Multisig.md
@@ -30,7 +30,7 @@ As as `OP_CHECKMULTISIG` locking script requires the "m" (`2`), the addresses, a
 ```
 2 $address1 $address2 2 OP_CHECKMULTISIG
 ```
-If this looks familiar, that's because it's the multisig that you deserialized in [§8.2: Building the Structure of P2SH](08_2_Building_the_Structure_of_P2SH.md).
+If this looks familiar, that's because it's the multisig that you deserialized in [§10.2: Building the Structure of P2SH](10_2_Building_the_Structure_of_P2SH.md).
 ```
 2 02da2f10746e9778dd57bd0276a4f84101c4e0a711f9cfd9f09cde55acbdd2d191 02bfde48be4aa8f4bf76c570e98a8d287f9be5638412ab38dede8e78df82f33fa3 2 OP_CHECKMULTISIG
 ```

--- a/10_5_Scripting_a_Segwit_Script.md
+++ b/10_5_Scripting_a_Segwit_Script.md
@@ -114,7 +114,7 @@ This works just like a P2WPKH address, the only difference being that instead of
 
 There is also one more variant, a P2WSH script embedded in a P2SH script, which works much like the P2SH-Segwit described above, but for nested P2WSH scripts. (Whew!)
 
-## Summary: Scripting a Pay to Witness Public Key Hash
+## Summary: Scripting a Segwit Script
 
 There are two sorts of P2SH scripts that relate to Segwit. 
 

--- a/10_6_Spending_a_P2SH_Transaction.md
+++ b/10_6_Spending_a_P2SH_Transaction.md
@@ -8,7 +8,7 @@ As we saw in [§6.2: Spending a Transaction with a Multisig](06_2_Spending_a_Tra
 
 ### Collect Your Variables
 
-Because P2SH addresses other than the special multisig and nested Segwit addresses aren't integrated into `bitcoin-cli` there will be no short-cuts for P2SH spending like you saw in [§6.3: Sending an Automated Multisig](6_3_Sending_an_Automated_Multisig.md). You're going to need to collect all the more complex variables on your own!
+Because P2SH addresses other than the special multisig and nested Segwit addresses aren't integrated into `bitcoin-cli` there will be no short-cuts for P2SH spending like you saw in [§6.3: Sending & Spending an Automated Multisig](6_3_Sending_an_Automated_Multisig.md). You're going to need to collect all the more complex variables on your own!
 
 This means that you need to collect:
 

--- a/10_6_Spending_a_P2SH_Transaction.md
+++ b/10_6_Spending_a_P2SH_Transaction.md
@@ -33,7 +33,7 @@ $ bitcoin-cli -named signrawtransactionwithkey hexstring=$rawtxhex prevtxs='''[ 
 ```
 With any other sort of P2SH you're going to be including a different `redeemscript`, but otherwise the practice is exactly the same. The only difference is that after two chapters of work on Scripts you now understand what the `scriptPubKey` is and what the `redeemScript` is, so hopefully what were mysterious elements four chapters ago are now old hat.
 
-## Summary: Spending a Transaction with a Bitcoin Script
+## Summary: Spending a P2SH Transaction
 
 You already spent a P2SH back in Chapter 6, when you resent a multsig transaction the hard way, which required lining up the `scriptPubKey` and `redeemScript` information. Now you know that the `scriptPubKey` is a standardized P2SH locking script, while the `redeemScript` matches a hash in that locking script and that you need to be able to run it with the proper variables to receive a `True` result. But other than knowing more, there's nothing new in spending a P2SH transaction, because you already did it!
 

--- a/10_6_Spending_a_P2SH_Transaction.md
+++ b/10_6_Spending_a_P2SH_Transaction.md
@@ -4,7 +4,7 @@ Before we close out this overview of P2SH transactions, we're going to touch upo
 
 ## Use the Redeem Script
 
-As we saw in [§6.2: Spending a Transaction to a Multisig](06_2_Spending_a_Transaction_to_a_Multisig.md), spending a P2SH transaction is all about having that serialized version of the locking script, the so-called _redeemScript_. So, the first step in being able to spend a P2SH transaction is making sure that you save the _redeemScript_ before you give out the P2SH address to everyone. 
+As we saw in [§6.2: Spending a Transaction with a Multisig](06_2_Spending_a_Transaction_to_a_Multisig.md), spending a P2SH transaction is all about having that serialized version of the locking script, the so-called _redeemScript_. So, the first step in being able to spend a P2SH transaction is making sure that you save the _redeemScript_ before you give out the P2SH address to everyone. 
 
 ### Collect Your Variables
 


### PR DESCRIPTION
Summary was mentioning the previous file's title instead of this one.