### PR TITLE
Add ports and fix note

### DIFF
--- a/15_0_Using_i2p.md
+++ b/15_0_Using_i2p.md
@@ -11,7 +11,15 @@ Basic differences between Tor and i2p:
 | Relay     | **Two-way** encrypted connections between each Relay       | **One-way** connections between every server in its tunnels      |
 | Hidden services     | Slow       | Fast      |
 
-Read more: https://geti2p.net/en/comparison/tor
+Comparison in detail: https://geti2p.net/en/comparison/tor
+
+Ports required by i2p:
+
+1. Outbound (Internet facing): a random port between 9000 and 31000 is selected however its better if all ports are open and it doesn't affect your security. You can check firewall status using `sudo ufw status verbose` which shouldn't deny outgoing by default.
+
+2. Inbound (Internet facing): Optional
+
+Local ports: https://geti2p.net/en/faq#ports
 
 It is not installed by [Bitcoin Standup](https://github.com/BlockchainCommons/Bitcoin-Standup-Scripts) right now as i2p support was recently added in Bitcoin core. However, you can try it manually by following the steps mentioned in [Section One](15_1_i2p_service.md).
 

--- a/15_1_i2p_service.md
+++ b/15_1_i2p_service.md
@@ -78,7 +78,7 @@ Follow the below steps to run Bitcoin Core i2p service:
 
 It is always good to have alternatives for privacy and not depend only on Tor to run Bitcoin Core as hidden service. Since i2p was recently added in Bitcoin Core, less people use it, experiment with it and report bugs if you find any issues.
 
-> :information_source: **NOTE:** _i2pd_ (C++) is different from _i2prouter_ (Java), you will need `i2pd` for Bitcoin Core.
+> :information_source: **NOTE:** For the official i2prouter implementation in Java, visit [download](https://geti2p.net/en/download) page and follow the instructions for your Operating System. Once installed, open a terminal window and type `i2prouter start`. Then visit `127.0.0.1:7657` in your browser to enable SAM. To do so, select: "Configure Homepage", then "Clients", and finally select the "Play Button" next to SAM application Bridge. On the left side of the page, there should be a green light next to "Shared Clients".
 
 Move on to "Programming with RPC" with [Chapter Sixteen: Talking to Bitcoind with C](16_0_Talking_to_Bitcoind.md).
 


### PR DESCRIPTION
+ Information about ports required for i2p (inbound and outbound)
+ i2prouter (java) works so note is incorrect. Changed it with information shared by Robert Spigler in https://github.com/bitcoin/bitcoin/pull/22648#discussion_r684835687
