### PR TITLE
Fix typo and add syntax highlighting in chapter 17.3

### DIFF
--- a/17_3_Using_BIP32_in_Libwally.md
+++ b/17_3_Using_BIP32_in_Libwally.md
@@ -97,7 +97,7 @@ Alternatively, you can use the `bip32_key_from_parent_alloc` function, which jus
   struct ext_key *key_address;  
   lw_response = bip32_key_from_parent_alloc(key_external,0,BIP32_FLAG_KEY_PRIVATE,&key_address);
 ```
-> :warning: **WARNING::** At some point in this hierarchy, you might decide to generate `BIP32_FLAG_KEY_PUBLIC` instead of `BIP32_FLAG_KEY_PRIVATE`. Obviously this decision will be based on your security and your needs, but remember that you only need a public key to generate the actual address.
+> :warning: **WARNING:** At some point in this hierarchy, you might decide to generate `BIP32_FLAG_KEY_PUBLIC` instead of `BIP32_FLAG_KEY_PRIVATE`. Obviously this decision will be based on your security and your needs, but remember that you only need a public key to generate the actual address.
 
 ### Generate an Address
 

--- a/17_3_Using_BIP32_in_Libwally.md
+++ b/17_3_Using_BIP32_in_Libwally.md
@@ -118,7 +118,7 @@ There is also a `wally_bip32_key_to_address` function, which can be used to gene
 The code for these HD example can, as usual, be found in the [src directory](src/17_3_genhd.c).
 
 You can compile and test it:
-```bash
+```
 $ cc genhd.c -lwallycore -lsodium -o genhd
 $ ./genhd
 Mnemonic: behind mirror pond finish borrow wood park foam guess mail regular reflect


### PR DESCRIPTION
Anotate code blocks with the names of the programming languages used improves the reading experience, although code from special libraries doesn't get highlighted.