### PR TITLE
Update Chapter 02.1 missing daemon first run

### DIFF
--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
@@ -139,6 +139,13 @@ $ ls
 bitcoin-0.20.0-x86_64-linux-gnu.tar.gz  laanwj-releases.asc  SHA256SUMS.asc
 ```
 
+If it's not case, maybe you are in the wrong home directory:
+```
+$ cd /home/standup
+$ ls
+bitcoin-0.20.0-x86_64-linux-gnu.tar.gz  laanwj-releases.asc  SHA256SUMS.asc
+```
+
 These are the various files that were used to install Bitcoin on your VPS. _None_ of them are necessary. We've just left them in case you want to do any additional verification. Otherwise, you can delete them:
 
 ```

--- a/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
+++ b/02_1_Setting_Up_a_Bitcoin-Core_VPS_with_StackScript.md
@@ -217,7 +217,12 @@ _If you'd like to know more about what the Bitcoin Standup stackscript does, ple
 
 So now you probably want to play with Bitcoin!
 
-But wait, your Bitcoin daemon is probably still downloading blocks. The `bitcoin-cli getblockcount` will tell you how you're currently doing:
+But wait, first you need to run the Bitcoin daemon:
+```
+$ bitcoind -daemon
+```
+
+Your Bitcoin daemon will start downloading blocks. The `bitcoin-cli getblockcount` will tell you how you're currently doing:
 ```
 $ bitcoin-cli getblockcount
 1771352


### PR DESCRIPTION
I noticed following the guide everything was working perfectly, but running `bitcoin-cli getblockcount` showed this:
````
error: Could not connect to the server 127.0.0.1:8332

Make sure the bitcoind server is running and that you are connecting to the correct RPC port.
````
I just noticed the daemon was not started