### PR TITLE
Update 04_2__Interlude_Using_JQ.md

### DIFF
--- a/04_2__Interlude_Using_JQ.md
+++ b/04_2__Interlude_Using_JQ.md
@@ -357,7 +357,7 @@ To complete the transaction fee calculation, you subtract the .vout .amount (1.0
 
 To do this, you'll need to install `bc`:
 ```
-$ sudo apt-get intall bc
+$ sudo apt-get install bc
 ```
 
 Putting it all together creates a complete calculator in just five lines of script:


### PR DESCRIPTION
An "s" was missing in the bc install command. Added "s" in bc install command (line 360).