### PR TITLE
Adding 'verbose=true' statement

### DIFF
--- a/04_6_Creating_a_Segwit_Transaction.md
+++ b/04_6_Creating_a_Segwit_Transaction.md
@@ -206,7 +206,7 @@ In fact, both of the `vouts` use Bech32 addresses: your recipient and the automa
 
 But when we backtrack our `vin`, we discover that came from a legacy address. Because it doesn't matter:
 ```
-$ bitcoin-cli -named gettransaction txid="33173618421804343e8f6cc21316d97a24f7439137510249af39f01ee82113a7"
+$ bitcoin-cli -named gettransaction txid="33173618421804343e8f6cc21316d97a24f7439137510249af39f01ee82113a7" verbose=true
 {
   "amount": 0.01000000,
   "confirmations": 43,


### PR DESCRIPTION
I suggest to also add the `'verbose=true'` statement to the inspection of the legacy address in line 209. This way, even someone who does not remember what a legacy address in the testnet looks like, will get the additional information of `"type": "pubkeyhash"` so it's easier to see that it is indeed a legacy address and not segwit.