### PR TITLE
added descriptors=false flag

### DIFF
--- a/07_3_Integrating_with_Hardware_Wallets.md
+++ b/07_3_Integrating_with_Hardware_Wallets.md
@@ -130,7 +130,7 @@ You can watch for funds by importing addresses from your hardware wallet to your
 
 To use your hardware wallet with `bitcoin-cli`, you'll want to create a specific named wallet in Bitcoin Core, using the `createwallet` RPC, which is a command we haven't previously discussed.
 ```
-$ bitcoin-cli --named createwallet wallet_name="ledger" disable_private_keys="true"
+$ bitcoin-cli --named createwallet wallet_name="ledger" disable_private_keys="true" descriptors="false"
 {
   "name": "ledger",
   "warning": ""


### PR DESCRIPTION
Creating the hardware wallet without `descriptors=false` flag results in the following error when running `importmulti`:

```
error code: -4
error message:
This type of wallet does not support this command
```