### PR TITLE
Uncomplicate btcblock alias and fix 301 error

### DIFF
--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -45,15 +45,13 @@ You can do this by looking at a blocknet explorer, such as [the Blockcypher Test
 
 If you'd like an alias to look at everything at once, the following currently works for Testnet, but may disappear at some time in the future:
 ```
-$ cat >> ~/.bash_profile << EOF
-alias btcblock="echo \\\`bitcoin-cli -testnet getblockcount 2>&1\\\`/\\\`wget -O - https://blockstream.info/testnet/api/blocks/tip/height 2> /dev/null | cut -d : -f2 | rev | cut -c 1- | rev\\\`"
-EOF
+$ echo "alias btcblock='echo \$(bitcoin-cli -testnet getblockcount)/\$(curl -s https://blockstream.info/testnet/api/blocks/tip/height)'" >> .bash_profile
 $ source .bash_profile 
 $ btcblock
 1804372/1804372
 ```
 
-> :link: **TESTNET vs MAINNET:** Remember that this tutorial generally assumes that you are using testnet. If you're using the mainnet instead, you can retrieve the current block height with: `wget -O - http://blockchain.info/q/getblockcount 2>/dev/null`. You can replace the latter half of the `btcblock` alias (after `/`) with that.
+> :link: **TESTNET vs MAINNET:** Remember that this tutorial generally assumes that you are using testnet. If you're using the mainnet instead, you can retrieve the current block height with: `curl -s https://blockchain.info/q/getblockcount`. You can replace the latter half of the `btcblock` alias (after `/\$(`) with that.
 
 If you're not up-to-date, but your `getblockcount` is increasing, no problem. Total download time can take from an hour to several hours, depending on your setup.
 


### PR DESCRIPTION
The btcblock alias was overly complicated requiring multiple cut commands and multiple line reversals due to using wget (which wasn't even installed on debian by default, whereas curl is). Using curl with the silent flag reduces complexity. Also removing the cat command double redirection using HERE doc notation and complicated escaping is accomplished with a single echo command and simply append redirect.

Update the mainnet get block call with curl and fix the 301 error received by calling url in plain text.