### PR TITLE
Check .bashrc for .bash_profile

### DIFF
--- a/03_1_Verifying_Your_Bitcoin_Setup.md
+++ b/03_1_Verifying_Your_Bitcoin_Setup.md
@@ -15,7 +15,14 @@ alias bd="bitcoind"
 alias btcinfo='bitcoin-cli getwalletinfo | egrep "\"balance\""; bitcoin-cli getnetworkinfo | egrep "\"version\"|connections"; bitcoin-cli getmininginfo | egrep "\"blocks\"|errors"'
 EOF
 ```
-After you enter these aliases you can either `source .bash_profile` to input them or just log out and back in.
+After you enter these aliases you can either `source .bash_profile` to input them or just log out and back in. If the latter doesn't work, add a small script at the end of `.bashrc` to load `.bash_profile` by default.
+```
+cat >> ~/.bashrc <<EOF
+if [ -f ~/.bash_profile ]; then
+  . ~/.bash_profile
+fi
+EOF
+```
 
 Note that these aliases includes shortcuts for running `bitcoin-cli`, for running `bitcoind`, and for going to the Bitcoin directory. These aliases are mainly meant to make your life easier. We suggest you create other aliases to ease your use of frequent commands (and arguments) and to minimize errors. Aliases of this sort can be even more useful if you have a complex setup where you regularly run commands associated with Mainnet, with Testnet, _and_ with Regtest, as explained further below.
 


### PR DESCRIPTION
I checked `.bashrc` and it loads `.bash_aliases` instead of `.bash_profile`. So, for me logging out and in didn't work.
```
# Alias definitions.
# You may want to put all your additions into a separate file like
# ~/.bash_aliases, instead of adding them here directly.
# See /usr/share/doc/bash-doc/examples in the bash-doc package.

if [ -f ~/.bash_aliases ]; then
    . ~/.bash_aliases
fi
```
So had to `source` in each session. Hence, added small script at the end of `.bashrc`. I think just renaming everywhere works but probably not for everyone. 
