### PR TITLE
Fix bc error with scientific numbers in txfee_calc

### DIFF
--- a/04_2__Interlude_Using_JQ.md
+++ b/04_2__Interlude_Using_JQ.md
@@ -372,7 +372,7 @@ $ usedtxid=($(bitcoin-cli decoderawtransaction $rawtxhex | jq -r '.vin | .[] | .
 $ usedvout=($(bitcoin-cli decoderawtransaction $rawtxhex | jq -r '.vin | .[] | .vout'))
 $ btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'${txid}'")) | select(.vout | contains('$vout')) | .amount'; done | awk '{s+=$1} END {print s}')
 $ btcout=$(bitcoin-cli decoderawtransaction $rawtxhex | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print s}')
-$ echo "$btcin-$btcout"| /usr/bin/bc
+$ echo $(printf '%.8f-%.8f' $btcin $btcout_f) | /usr/bin/bc
 .255
 ```
 And that's also a good example of why you double-check your fees: we'd intended to send a transaction fee of 5,000 satoshis, but sent 255,000 satoshis instead. Whoops!

--- a/src/04_2_i_txfee-calc.sh
+++ b/src/04_2_i_txfee-calc.sh
@@ -11,4 +11,4 @@ usedvout=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .vout'))
 btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'${txid}'")) | select(.vout | contains('$vout')) | .amount'; done | awk '{s+=$1} END {print s}')
 btcout=$(bitcoin-cli decoderawtransaction $1 | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print s}')
 btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%f\n", btcout) }' </dev/null)
-echo "$btcin-$btcout_f"| /usr/bin/bc
+echo $(printf '%.8f-%.8f' $btcin $btcout_f) | /usr/bin/bc


### PR DESCRIPTION
bitcoin-cli sometimes returns scientific numbers, which results in errors with bc

``` bash
$ ./txfee-calc.sh $signedtx
(standard_in) 1: syntax error

$ echo "$btcin-$btcout_f"
8.859e-05-0.000088

# fixed by rewriting numbers with printf
$ echo $(printf '%.8f-%.8f' $btcin $btcout_f) | /usr/bin/bc
.00000059
```