### PR TITLE
AbuShafrah-review

### DIFF
--- a/src/04_2_i_txfee-calc.sh
+++ b/src/04_2_i_txfee-calc.sh
@@ -8,7 +8,7 @@ fi
 
 mapfile -t usedtxid < <(bitcoin-cli decoderawtransaction "$1" | jq -r '.vin | .[] | .txid')
 mapfile -t usedvout < <(bitcoin-cli decoderawtransaction "$1" | jq -r '.vin | .[] | .vout')
-btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'"${txid}"'")) | select(.vout | contains('"$vout"')) | .amount'; done | awk '{s+=$1} END {print s}')
-btcout=$(bitcoin-cli decoderawtransaction "$1" | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print "%.8f\n, s}')
+btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'"${txid}"'")) | select(.vout | contains('"$vout"')) | .amount'; done | awk '{s+=$1} END {printf "%.8f\n, s}')
+btcout=$(bitcoin-cli decoderawtransaction "$1" | jq -r '.vout  [] | .value' | awk '{s+=$1} END {printf "%.8f\n, s}')
 btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%.8f\n", btcout) }' </dev/null)
 echo "$btcin-$btcout_f"| /usr/bin/bc

--- a/src/04_2_i_txfee-calc.sh
+++ b/src/04_2_i_txfee-calc.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-if [ -z $1 ];
+if [ -z "$1" ];
 then
     echo "You must include the raw transaction hex as an argument.";
     exit;
 fi
 
-usedtxid=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .txid'))
-usedvout=($(bitcoin-cli decoderawtransaction $1 | jq -r '.vin | .[] | .vout'))
-btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'${txid}'")) | select(.vout | contains('$vout')) | .amount'; done | awk '{s+=$1} END {print s}')
-btcout=$(bitcoin-cli decoderawtransaction $1 | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print s}')
-btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%f\n", btcout) }' </dev/null)
+mapfile -t usedtxid < <(bitcoin-cli decoderawtransaction "$1" | jq -r '.vin | .[] | .txid')
+mapfile -t usedvout < <(bitcoin-cli decoderawtransaction "$1" | jq -r '.vin | .[] | .vout')
+btcin=$(for ((i=0; i<${#usedtxid[*]}; i++)); do txid=${usedtxid[i]}; vout=${usedvout[i]}; bitcoin-cli listunspent | jq -r '.[] | select (.txid | contains("'"${txid}"'")) | select(.vout | contains('"$vout"')) | .amount'; done | awk '{s+=$1} END {print s}')
+btcout=$(bitcoin-cli decoderawtransaction "$1" | jq -r '.vout  [] | .value' | awk '{s+=$1} END {print "%.8f\n, s}')
+btcout_f=$(awk -v btcout="$btcout" 'BEGIN { printf("%.8f\n", btcout) }' </dev/null)
 echo "$btcin-$btcout_f"| /usr/bin/bc


### PR DESCRIPTION
There was a rounding error that happened that wasn't resolved without setting the decimal point to 8 decimal. Without this, it occationally rounded down the satoshis resulting in a miscalculation.

Also, I changed the way the arrays were created to be more robust, along with adding quotations in accordance to ShellCheck 2086 https://www.shellcheck.net/wiki/SC2086.